### PR TITLE
Fix news layout for firefox.

### DIFF
--- a/views/news.html
+++ b/views/news.html
@@ -2,7 +2,7 @@
     <p>&nbsp;</p>
     <div class="gdg_loading" ng-show="loading"></div>
     <h1 class="span12" ng-hide="loading">{{ chapter_name }} News</h1>
-    <ul id="news-feed">
+    <ul class="span12" id="news-feed">
         <li ng-repeat="article in news">
 
             <img class="icon" ng-src="{{ article.icon }}" alt="Article Icon" />


### PR DESCRIPTION
Fix the layout for Firefox (Tested with version 30, 31 and 32).
Without, the first post is unreadable small at the right edge of the window:

Before: http://www.browserstack.com/screenshots/6b8d1e072bd491f1faa29c5a1883a2fda0a06792
After: http://www.browserstack.com/screenshots/14f8f0a2b83f6a84087a8a7470ec4a308fc82e7b
