### PR TITLE
Fix issue 26, new events not showing up when using Hub API

### DIFF
--- a/js/boomerang.js
+++ b/js/boomerang.js
@@ -157,15 +157,25 @@ boomerang.controller("EventsControl", function ($scope, $http, Config) {
             $scope.status = 'ready';
         });
 
-    url = 'http://hub.gdgx.io/api/v1/chapters/' + Config.id + '/events/past?callback=JSON_CALLBACK';
-    $http.jsonp(url, headers)
-        .success(function (data) {
-            for (var i = data.items.length - 1; i >= 0; i--) {
-                $scope.events.past.push(data.items[i]);
-            }
-            $scope.loading = false;
-            $scope.status = 'ready';
-        });
+    var getPastEventsPage = function(page) {
+        var url = 'http://hub.gdgx.io/api/v1/chapters/' + Config.id + '/events/past?callback=JSON_CALLBACK&page=' + page;
+        var headers = { 'headers': {'Accept': 'application/json;'}, 'timeout': 2000 };
+        $http.jsonp(url, headers)
+            .success(function (data) {
+                var i;
+                for (i = data.items.length - 1; i >= 0; i--) {
+                    data.items[i].about = data.items[i].about.replace(/<br \/><br\/><br\/><br \/>/g, '<br/><br/>');
+                    $scope.events.past.push(data.items[i]);
+                }
+                if (data.pages === page) {
+                    $scope.loading = false;
+                    $scope.status = 'ready';
+                } else {
+                    getPastEventsPage(page + 1);
+                }
+            });
+    };
+    getPastEventsPage(1);
 });
 
 boomerang.controller("PhotosControl", function ($scope, $http, Config) {

--- a/js/config.js
+++ b/js/config.js
@@ -7,11 +7,11 @@ boomerang.factory('Config', function () {
         'pwa_id'        : '5915725140705884785', //picasa web album id, must belong to google+ id above
         'domain'        : 'http://www.gdgspacecoast.org',
         'cover' : {
-            title: 'Google I/O 2014',
-            subtitle: 'Google\'s yearly developer event is being held June 25-26th in San Francisco, CA.',
+            title: 'Chrome Dev Summit',
+            subtitle: 'Connecting you with Chrome Engineers. November 19-20th, 2014. Mountain View, CA and live stream.',
             button: {
                 text: 'Find out more',
-                url: 'https://www.google.com/events/io'
+                url: 'https://developer.chrome.com/devsummit/'
             }
         }
     };

--- a/js/config.js
+++ b/js/config.js
@@ -7,11 +7,11 @@ boomerang.factory('Config', function () {
         'pwa_id'        : '5915725140705884785', //picasa web album id, must belong to google+ id above
         'domain'        : 'http://www.gdgspacecoast.org',
         'cover' : {
-            title: 'Chrome Dev Summit',
-            subtitle: 'Connecting you with Chrome Engineers. November 19-20th, 2014. Mountain View, CA and live stream.',
+            title: 'Google I/O 2014',
+            subtitle: 'Google\'s yearly developer event is being held June 25-26th in San Francisco, CA.',
             button: {
                 text: 'Find out more',
-                url: 'https://developer.chrome.com/devsummit/'
+                url: 'https://www.google.com/events/io'
             }
         }
     };


### PR DESCRIPTION
Implemented loading all data for past events by loading each page of data from the API.
Updated cover to Chrome Dev Summit.

This also includes a work around for https://github.com/gdg-x/hub/issues/12