### PR TITLE
Fix photos error display

### DIFF
--- a/app/events/events.html
+++ b/app/events/events.html
@@ -21,7 +21,7 @@
             <p ng-bind-html="event.about | htmlLinky | hashLinky"></p>
         </md-card-content>
     </md-card>
-    <p ng-if="vm.upcomingError" ng-bind-html="vm.upcomingError" style="margin: 8px"></p>
+    <h4 ng-if="vm.upcomingError" ng-bind-html="vm.upcomingError" style="margin: 8px"></h4>
 </md-whiteframe>
 <md-whiteframe class="md-whiteframe-z1" layout="column" layout-margin>
     <md-toolbar>
@@ -45,5 +45,5 @@
             <p ng-bind-html="event.about | htmlLinky | hashLinky"></p>
         </md-card-content>
     </md-card>
-    <p ng-if="vm.pastError" ng-bind-html="vm.pastError" style="margin: 8px"></p>
+    <h4 ng-if="vm.pastError" ng-bind-html="vm.pastError" style="margin: 8px"></h4>
 </md-whiteframe>

--- a/app/photos/photos.html
+++ b/app/photos/photos.html
@@ -1,12 +1,12 @@
 <div class="gdg_loading" ng-show="vm.loading"></div>
-<md-whiteframe class="md-whiteframe-z1" layout="column" layout-margin ng-show="vm.photos.length">
+<md-whiteframe class="md-whiteframe-z1" layout="column" layout-margin>
     <md-toolbar>
         <div class="md-toolbar-tools">
             <h3>{{ vm.chapterName }} Images</h3>
         </div>
     </md-toolbar>
-    <p ng-show="vm.errorMsg">{{ vm.errorMsg }}</p>
-    <md-grid-list
+    <h4 ng-show="vm.errorMsg" style="padding: 0 8px 0 8px">{{ vm.errorMsg }}</h4>
+    <md-grid-list ng-show="vm.photos.length"
             md-cols-sm="1" md-cols-md="2" md-cols-gt-md="3"
             md-row-height-gt-md="1:1" md-row-height="2:2"
             md-gutter="12px" md-gutter-gt-sm="8px">

--- a/app/photos/photos.js
+++ b/app/photos/photos.js
@@ -29,7 +29,7 @@ angular.module('gdgXBoomerang')
             vm.loading = false;
         })
         .error(function () {
-            vm.errorMsg = 'Sorry, we failed to retrieve the Photos from the Picasa Web Albums API. ' +
+            vm.errorMsg = 'Sorry, we failed to retrieve the photos from the Picasa Web Albums API. ' +
                 'Logging out of your Google Account and logging back in may resolve this issue.';
             vm.loading = false;
         });


### PR DESCRIPTION
Fix issue where errors on the photos page would leave the user with a blank page
Change errors to h4 to make them more visible. Improve styling a little.