### PR TITLE
update(nav):  add adaptive UI features: transformation of tabs<->sidenav

### DIFF
--- a/app/boomerang.module.js
+++ b/app/boomerang.module.js
@@ -1,5 +1,5 @@
 angular.module('gdgXBoomerang', ['ngRoute', 'ngSanitize', 'ngAria', 'ngAnimate', 'ngMaterial'])
-.controller('MainController', function ($rootScope, Config, NavService) {
+.controller('MainController', function ($rootScope, $mdMedia, $mdSidenav, Config, NavService) {
     var mc = this;
     mc.chapterName = Config.name;
     mc.googlePlusLink = 'https://plus.google.com/' + Config.id;
@@ -7,6 +7,8 @@ angular.module('gdgXBoomerang', ['ngRoute', 'ngSanitize', 'ngAria', 'ngAnimate',
     mc.twitterLink = Config.twitter ? 'https://twitter.com/' + Config.twitter : null;
     mc.facebookLink = Config.facebook ? 'https://www.facebook.com/' + Config.facebook : null;
     mc.meetupLink = Config.meetup ? 'http://www.meetup.com/' + Config.meetup : null;
+    $rootScope.$mdMedia = $mdMedia;
+    $rootScope.$mdSidenav = $mdSidenav;
     $rootScope.canonical = Config.domain;
 
     NavService.registerNavListener(function (tab) {

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
         "angular-sanitize": "1.4.7",
         "angular-aria": "1.4.7",
         "angular-animate": "1.4.7",
-        "angular-material": "0.11.2",
+        "angular-material": "1.0.0-rc1",
+        "google-material-icons": "0.1.0",
         "font-awesome": "~4.3.0"
     },
     "devDependencies": {

--- a/config/CDN.json
+++ b/config/CDN.json
@@ -6,11 +6,12 @@
         "https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-aria.min.js",
         "https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-route.min.js",
         "https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-sanitize.min.js",
-        "https://ajax.googleapis.com/ajax/libs/angular_material/0.11.2/angular-material.min.js"
+        "https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0-rc1/angular-material.min.js"
     ],
     "css":
     [
-        "https://ajax.googleapis.com/ajax/libs/angular_material/0.11.2/angular-material.min.css",
-        "//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"
+        "https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0-rc1/angular-material.min.css",
+        "//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css",
+        "https://fonts.googleapis.com/icon?family=Material+Icons"
     ]
 }

--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
         <link href="https://fonts.googleapis.com/css?family=RobotoDraft:400,300,500,700,400italic" rel="stylesheet" >
         <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,700italic,300,700' rel='stylesheet'>
         <!-- bower:css -->
-        <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.11.2/angular-material.min.css">
+        <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0-rc1/angular-material.min.css">
         <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <!-- endinject -->
         <!-- inject:css -->
         <link rel="stylesheet" href="app/css/gdg.css">
@@ -36,12 +37,16 @@
         <span itemprop="description" style="display: none;">Google Developer Group (GDG) Space Coast is a technology user group that meets to discuss the latest Google Technologies, Tools, SDKs, and APIs.</span>
         <img itemprop="image" style="display: none;" src="app/images/GDG-X-Boomerang-snippet.png">
 
-        <md-toolbar class="md-hue-2 navBar">
+        <md-toolbar class="md-hue-2 navBar" ng-class="{ 'md-tall': $mdMedia('sm') }">
             <div class="md-toolbar-tools">
-                <h2 flex>
+                <md-button class="md-icon-button" hide-gt-sm ng-click="$mdSidenav('left').open()" flex="none">
+                    <md-icon>menu</md-icon>
+                </md-button>
+                <h2 hide-sm>
                     <span ng-cloak>{{ mc.chapterName }}</span>
                 </h2>
-                <div hide-sm>
+                <span flex></span>
+                <div>
                     <div class="g-plusone" data-size="large"></div>
                 </div>
                 <a ng-if="mc.googlePlusLink" ng-href="{{ mc.googlePlusLink }}" rel="publisher" target="_blank">
@@ -60,8 +65,12 @@
                     <img src="app/images/icons/GDG_square_lg.png" alt="GDG" class="png-icon gdg-icon grayscale">
                 </a>
             </div>
+            <h2 class="md-toolbar-tools md-toolbar-tools-bottom" hide-gt-sm ng-cloak>
+                {{ mc.chapterName }}
+            </h2>
         </md-toolbar>
-        <md-tabs class="navTabs" md-selected="mc.navTab" md-stretch-tabs="never">
+
+        <md-tabs class="navTabs" md-selected="mc.navTab" md-stretch-tabs="never" hide-sm>
             <md-tab id="about-tab"><a class="navTabLink" href="#!/about">About</a></md-tab>
             <md-tab id="news-tab"><a class="navTabLink" href="#!/news">News</a></md-tab>
             <md-tab id="events-tab"><a class="navTabLink" href="#!/events">Events</a></md-tab>
@@ -69,6 +78,32 @@
             <md-tab id="organizers-tab"><a class="navTabLink" href="#!/organizers">Organizers</a></md-tab>
             <md-tab id="photos-tab"><a class="navTabLink" href="#!/photos">Photos</a></md-tab>
         </md-tabs>
+
+        <md-sidenav class="md-sidenav-left md-whiteframe-2dp" md-component-id="left">
+          <md-content>
+            <md-list>
+                <md-list-item href="#!/about" ng-click="$mdSidenav('left').close()">
+                  About
+                </md-list-item>
+                <md-list-item href="#!/news" ng-click="$mdSidenav('left').close()">
+                  News
+                </md-list-item>
+                <md-list-item href="#!/events" ng-click="$mdSidenav('left').close()">
+                  Events
+                </md-list-item>
+                <md-list-item href="#!/activities" ng-click="$mdSidenav('left').close()">
+                  What We Do
+                </md-list-item>
+                <md-list-item href="#!/organizers" ng-click="$mdSidenav('left').close()">
+                  Organizers
+                </md-list-item>
+                <md-list-item href="#!/photos" ng-click="$mdSidenav('left').close()">
+                  Photos
+                </md-list-item>
+            </md-list>
+          </md-content>
+        </md-sidenav>
+
         <div layout layout-margin layout-align="center start">
             <div ng-view flex-sm="100" flex-md="90" flex-lg="80" flex-gt-lg="75"></div>
         </div>
@@ -80,7 +115,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-aria.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-route.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular-sanitize.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.11.2/angular-material.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.0.0-rc1/angular-material.min.js"></script>
     <!-- endinject -->
     <!-- inject:js -->
     <script src="app/dist/boomerang.min.js"></script>


### PR DESCRIPTION
upgrade to angular-material 1.0.0-rc1
add google-material-icons font set
show tabs on screens larger than small
show sidenav on small screens
small toolbar on large screens, tall toolbar on small screens to allow icons and chapter name to fit

Desktop looks the same as before:
![screen shot 2015-11-02 at 12 15 42 am](https://cloud.githubusercontent.com/assets/3506071/10874730/31e9243e-80f7-11e5-9169-f1cb1679308a.png)

New look on mobile:
![screen shot 2015-11-02 at 12 14 55 am](https://cloud.githubusercontent.com/assets/3506071/10874729/3054803c-80f7-11e5-87b0-0273438d208b.png)

SideNav open:
![screen shot 2015-11-02 at 12 19 13 am](https://cloud.githubusercontent.com/assets/3506071/10874741/6ea44d72-80f7-11e5-9ec0-cff4c40c18fd.png)
