### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Sites using this template
 * http://gdga-site.appspot.com/
 * http://gdg.nz/
 
-###Contributors
+### Contributors
 See [list of contributors](https://github.com/gdg-x/boomerang/graphs/contributors)
 
 Maintainer: [Splaktar](https://github.com/Splaktar).
 
-######GDG Apps, GDG[x] are not endorsed and/or supported by Google, the corporation.
+###### GDG Apps, GDG[x] are not endorsed and/or supported by Google, the corporation.
 
 License
 --------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
